### PR TITLE
Fixes with staticfiles

### DIFF
--- a/lizard_blockbox/import_helpers.py
+++ b/lizard_blockbox/import_helpers.py
@@ -242,41 +242,22 @@ def merge_measures_blockbox(stdout):
     stdout.write("Merged blockbox measures...\n")
 
 
-# Copy JSON to blockbox command
+# Copy JSON to media command
 
-def copy_json_to_blockbox(stdout):
+def copy_json_to_media(stdout):
     JSON_DIR = os.path.join(settings.BUILDOUT_DIR, 'deltaportaal',
                             'data', 'geojson')
-    STATIC_DIR = os.path.join(settings.BUILDOUT_DIR, 'deltaportaal',
-                              'static', 'lizard_blockbox')
+    MEDIA_DIR = os.path.join(settings.MEDIA_ROOT, 'lizard_blockbox')
 
-    if not os.path.isdir(STATIC_DIR):
-        os.mkdir(STATIC_DIR)
+    if not os.path.isdir(MEDIA_DIR):
+        os.mkdir(MEDIA_DIR)
 
-    shutil.copyfile(
-        os.path.join(JSON_DIR, 'measures.json'),
-        os.path.join(STATIC_DIR, 'measures.json'))
+    for fn in ('measures.json', 'kilometers.json'):
+        shutil.copyfile(
+            os.path.join(JSON_DIR, fn),
+            os.path.join(MEDIA_DIR, fn))
 
-    shutil.copyfile(
-        os.path.join(JSON_DIR, 'kilometers.json'),
-        os.path.join(STATIC_DIR, 'kilometers.json'))
-    stdout.write("Copied json to blockbox...\n")
-
-    # also update the files in settings.STATIC_ROOT
-
-    COLLECTED_STATIC = os.path.join(settings.STATIC_ROOT, 'lizard_blockbox')
-
-    if not os.path.isdir(COLLECTED_STATIC):
-        os.mkdir(COLLECTED_STATIC)
-
-    shutil.copyfile(
-        os.path.join(JSON_DIR, 'measures.json'),
-        os.path.join(COLLECTED_STATIC, 'measures.json'))
-
-    shutil.copyfile(
-        os.path.join(JSON_DIR, 'kilometers.json'),
-        os.path.join(COLLECTED_STATIC, 'kilometers.json'))
-    stdout.write("Copied json to static...\n")
+    stdout.write("Copied json to media...\n")
 
 
 # Parse trajectory classification command

--- a/lizard_blockbox/import_helpers.py
+++ b/lizard_blockbox/import_helpers.py
@@ -247,7 +247,8 @@ def merge_measures_blockbox(stdout):
 def copy_json_to_blockbox(stdout):
     JSON_DIR = os.path.join(settings.BUILDOUT_DIR, 'deltaportaal',
                             'data', 'geojson')
-    STATIC_DIR = os.path.join(settings.STATIC_ROOT, 'lizard_blockbox')
+    STATIC_DIR = os.path.join(settings.BUILDOUT_DIR, 'deltaportaal',
+                              'static', 'lizard_blockbox')
 
     if not os.path.isdir(STATIC_DIR):
         os.mkdir(STATIC_DIR)
@@ -260,6 +261,22 @@ def copy_json_to_blockbox(stdout):
         os.path.join(JSON_DIR, 'kilometers.json'),
         os.path.join(STATIC_DIR, 'kilometers.json'))
     stdout.write("Copied json to blockbox...\n")
+
+    # also update the files in settings.STATIC_ROOT
+
+    COLLECTED_STATIC = os.path.join(settings.STATIC_ROOT, 'lizard_blockbox')
+
+    if not os.path.isdir(COLLECTED_STATIC):
+        os.mkdir(COLLECTED_STATIC)
+
+    shutil.copyfile(
+        os.path.join(JSON_DIR, 'measures.json'),
+        os.path.join(COLLECTED_STATIC, 'measures.json'))
+
+    shutil.copyfile(
+        os.path.join(JSON_DIR, 'kilometers.json'),
+        os.path.join(COLLECTED_STATIC, 'kilometers.json'))
+    stdout.write("Copied json to static...\n")
 
 
 # Parse trajectory classification command

--- a/lizard_blockbox/management/commands/copy_json_to_media.py
+++ b/lizard_blockbox/management/commands/copy_json_to_media.py
@@ -5,7 +5,7 @@ from lizard_blockbox import import_helpers
 
 class Command(BaseCommand):
     args = ''
-    help = ("Copy the geojson shape files to the static directory for Django")
+    help = ("Copy the geojson shape files to the media directory for Django")
 
     def handle(self, *args, **kwargs):
-        import_helpers.copy_json_to_blockbox(self.stdout)
+        import_helpers.copy_json_to_media(self.stdout)

--- a/lizard_blockbox/management/commands/run_import.py
+++ b/lizard_blockbox/management/commands/run_import.py
@@ -14,4 +14,4 @@ class Command(BaseCommand):
         import_helpers.parse_shapes_blockbox(self.stdout)
         import_helpers.parse_kilometers_json(self.stdout)
         import_helpers.merge_measures_blockbox(self.stdout)
-        import_helpers.copy_json_to_blockbox(self.stdout)
+        import_helpers.copy_json_to_media(self.stdout)

--- a/lizard_blockbox/templates/lizard_blockbox/blockbox.html
+++ b/lizard_blockbox/templates/lizard_blockbox/blockbox.html
@@ -186,7 +186,7 @@ href="#"><i class="icon-info-sign icon-grey"></i></a>
 
 {% block content %}
   <div id="lizard-blockbox-graph" class="i-have-height"
-       data-static-url="{{ STATIC_URL }}">
+       data-static-url="{{ MEDIA_URL }}">
     {% block lizard-blockbox-graph %}
       <div id="measure_results_graph"></div>
       <!-- measure_results_graph is the actual graph. -->

--- a/lizard_blockbox/views.py
+++ b/lizard_blockbox/views.py
@@ -685,11 +685,6 @@ class BookmarkedMeasuresView(RedirectView):
 def fetch_factsheet(request, measure):
     """Return download header for nginx to serve pdf file."""
 
-    # ToDo: Better security model based on views...
-    if not ApplicationIcon.objects.filter(url__startswith='/blokkendoos'):
-        # ToDo: Change to 403 with templates
-        raise Http404
-
     if not measure in _available_factsheets():
         # There is no factsheet for this measure
         raise Http404


### PR DESCRIPTION
This fixes two issues found on staging:
 - The management command `copy_json_to_blockbox` copied the required static geojson files to the STATIC_DIR. On a new deploy, the STATIC_DIR was wiped by `collectstatic`. Now, the files are copied to the `deltaportaal/static/lizard_blockbox` as well as to the `var/static`.
- There was some old and not working verification based on `ApplicationIcon` in `fetch_factsheet`. This is unneeded now; the `@permission_required()` decorator does the authentication already. Another issue with the factsheets was the NGINX X-Accel configruration, which is solved in deltaportaal