### PR TITLE
Management commands new-style

### DIFF
--- a/lizard_blockbox/management/commands/copy_json_to_media.py
+++ b/lizard_blockbox/management/commands/copy_json_to_media.py
@@ -4,7 +4,6 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Copy the geojson shape files to the media directory for Django")
 
     def handle(self, *args, **kwargs):

--- a/lizard_blockbox/management/commands/fetch_blockbox_data.py
+++ b/lizard_blockbox/management/commands/fetch_blockbox_data.py
@@ -4,7 +4,6 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Fetch the data from the ftp server.")
 
     def handle(self, *args, **kwargs):

--- a/lizard_blockbox/management/commands/import_city_names.py
+++ b/lizard_blockbox/management/commands/import_city_names.py
@@ -6,14 +6,16 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the city excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
+        if not options.get('excelfile', None):
             print "Pass excel files as arguments."
             sys.exit(1)
 
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.import_city_names(excelpath, self.stdout)

--- a/lizard_blockbox/management/commands/import_excluding_measures.py
+++ b/lizard_blockbox/management/commands/import_excluding_measures.py
@@ -6,15 +6,17 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the excluding measurements excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
+        if not options.get('excelfile', None):
             print "Pass excel files as arguments."
             sys.exit(1)
 
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.import_excluding_measures_xls(
                 excelpath, self.stdout)

--- a/lizard_blockbox/management/commands/import_geojson.py
+++ b/lizard_blockbox/management/commands/import_geojson.py
@@ -6,11 +6,13 @@ from lizard_blockbox import models
 
 
 class Command(BaseCommand):
-    args = '<geojson geojson ...>'
     help = "Imports the measure geojson file"
 
+    def add_arguments(self, parser):
+        parser.add_argument('geojson', nargs='+')
+
     def handle(self, *args, **options):
-        map(self.parse, args)
+        map(self.parse, options['geojson'])
 
     def parse(self, json_file):
         data = json.load(open(json_file, 'rb'))

--- a/lizard_blockbox/management/commands/import_including_measures.py
+++ b/lizard_blockbox/management/commands/import_including_measures.py
@@ -6,15 +6,17 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the including measurements excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
+        if not options.get('excelfile', None):
             print "Pass excel files as arguments."
             sys.exit(1)
 
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.import_including_measures_xls(
                 excelpath, self.stdout)

--- a/lizard_blockbox/management/commands/import_measure_table_xls.py
+++ b/lizard_blockbox/management/commands/import_measure_table_xls.py
@@ -6,14 +6,16 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the measures table excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
-            print "Pass excel files as arguments."
+        if not options.get('excelfile', None):
+            print("Pass excel files as arguments.")
             sys.exit(1)
 
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.import_measure_table_xls(excelpath, self.stdout)

--- a/lizard_blockbox/management/commands/import_measure_xls.py
+++ b/lizard_blockbox/management/commands/import_measure_xls.py
@@ -11,11 +11,12 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    args = '<directory> OR <excelfile excelfile ...>'
     help = ("Imports measure excelfiles, "
             "use --flush to flush the previous imports.")
 
     def add_arguments(self, parser):
+        parser.add_argument('directory_or_excelfile', nargs='+')
+
         parser.add_argument(
             '--flush',
             action='store_true',
@@ -29,6 +30,7 @@ class Command(BaseCommand):
         if flush:
             import_helpers.flush_database(self.stdout)
 
+        args = options.get('directory_or_excelfile', [])
         if len(args) == 0:
             if not flush:
                 print "Pass a directory as argument."

--- a/lizard_blockbox/management/commands/import_trajectory_classification_xls.py
+++ b/lizard_blockbox/management/commands/import_trajectory_classification_xls.py
@@ -6,16 +6,18 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the trajectory classifications excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
+        if not options.get('excelfile', None):
             print "Pass excel files as arguments."
             sys.exit(1)
 
         self.stdout.write("Import trajectindeling...\n")
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.parse_trajectory_classification_excelfile(
                 excelpath, self.stdout)

--- a/lizard_blockbox/management/commands/import_trajectory_names_xls.py
+++ b/lizard_blockbox/management/commands/import_trajectory_names_xls.py
@@ -6,15 +6,17 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the trajectory excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
+        if not options.get('excelfile', None):
             print "Pass excel files as arguments."
             sys.exit(1)
 
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.import_trajectory_names_xls(
                 excelpath, self.stdout)

--- a/lizard_blockbox/management/commands/import_vertex_xls.py
+++ b/lizard_blockbox/management/commands/import_vertex_xls.py
@@ -6,16 +6,18 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = '<excelfile excelfile ...>'
     help = ("Imports the vertex excelfile, "
             "To flush use the management command: import_measure_xls --flush")
 
+    def add_arguments(self, parser):
+        parser.add_argument('excelfile', nargs='+')
+
     def handle(self, *args, **options):
-        if len(args) == 0:
+        if not options.get('excelfile', None):
             print "Pass excel files as arguments."
             sys.exit(1)
 
-        for excelpath in args:
+        for excelpath in options['excelfile']:
             import_helpers.import_vertex_xls(excelpath, self.stdout)
 
         import_helpers.link_vertices_with_namedreaches()

--- a/lizard_blockbox/management/commands/load_blockbox_data.py
+++ b/lizard_blockbox/management/commands/load_blockbox_data.py
@@ -9,7 +9,6 @@ DATA_DIR = os.path.join(settings.BUILDOUT_DIR, 'deltaportaal/data')
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Run a data import using fab.")
 
     def handle(self, *args, **kwargs):

--- a/lizard_blockbox/management/commands/parse_kilometers_json.py
+++ b/lizard_blockbox/management/commands/parse_kilometers_json.py
@@ -4,7 +4,6 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Simplify kilometers shape.")
 
     def handle(self, *args, **kwargs):

--- a/lizard_blockbox/management/commands/parse_shapes_blockbox.py
+++ b/lizard_blockbox/management/commands/parse_shapes_blockbox.py
@@ -4,7 +4,6 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Parse the shapes for the blockbox data.")
 
     def handle(self, *args, **kwargs):

--- a/lizard_blockbox/management/commands/run_import.py
+++ b/lizard_blockbox/management/commands/run_import.py
@@ -4,7 +4,6 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Run a data import using fab.")
 
     def handle(self, *args, **kwargs):

--- a/lizard_blockbox/management/commands/set_permissions_pdf.py
+++ b/lizard_blockbox/management/commands/set_permissions_pdf.py
@@ -4,7 +4,6 @@ from lizard_blockbox import import_helpers
 
 
 class Command(BaseCommand):
-    args = ''
     help = ("Set read permissions for the facsheets.")
 
     def handle(self, *args, **kwargs):


### PR DESCRIPTION
De management commands die argumenten nodig hebben werkten niet meer, omdat dit anders werkt in django 1.11. Ik heb het even voor allemaal aangepast.